### PR TITLE
Expose ClientTLS in skipper options for passing client TLS settings

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -190,6 +190,9 @@ type Params struct {
 
 	// MaxIdleConns limits the number of idle connections to all backends, 0 means no limit
 	MaxIdleConns int
+
+	// Client TLS to connect to Backends
+	ClientTLS *tls.Config
 }
 
 var (
@@ -497,6 +500,10 @@ func WithParams(p Params) *Proxy {
 		IdleConnTimeout:       p.CloseIdleConnsPeriod,
 	}
 
+	if p.ClientTLS != nil {
+		tr.TLSClientConfig = p.ClientTLS
+	}
+
 	quit := make(chan struct{})
 	// We need this to reliably fade on DNS change, which is right
 	// now not fixed with IdleConnTimeout in the http.Transport.
@@ -515,7 +522,11 @@ func WithParams(p Params) *Proxy {
 	}
 
 	if p.Flags.Insecure() {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		} else {
+			tr.TLSClientConfig.InsecureSkipVerify = true
+		}
 	}
 
 	m := metrics.Default

--- a/skipper.go
+++ b/skipper.go
@@ -374,6 +374,9 @@ type Options struct {
 	// TLS Settings for Proxy Server
 	ProxyTLS *tls.Config
 
+	// Client TLS to connect to Backends
+	ClientTLS *tls.Config
+
 	// Flush interval for upgraded Proxy connections
 	BackendFlushInterval time.Duration
 


### PR DESCRIPTION
Expose ClientTLS in skipper options for passing client TLS settings

- Allows passing custom CA list or client certificates for connecting to backends

Signed-off-by: UltraNemesis dev.ajayabraham@gmail.com